### PR TITLE
fix exception if device cannot produce electricity

### DIFF
--- a/VitoConnect/module.php
+++ b/VitoConnect/module.php
@@ -344,7 +344,9 @@ class VitoConnect extends IPSModule
                         case 'week':
                         case 'month':
                         case 'year':
-                            $updateVariable($entity->class[0], $name, $property->type, $property->value[0] /* 0 = current period */, 'Electricity');
+                            // Fetching values only if device can produce electricity
+                            if (count($property->value)>1)
+                                $updateVariable($entity->class[0], $name, $property->type, $property->value[0] /* 0 = current period */, 'Electricity');
                             break;
                         default:
                             $this->SendDebug($name, $entity->class[0] . ' = ' . print_r($property, true), 0);

--- a/VitoConnect/module.php
+++ b/VitoConnect/module.php
@@ -344,9 +344,10 @@ class VitoConnect extends IPSModule
                         case 'week':
                         case 'month':
                         case 'year':
-                            // Fetching values only if device can produce electricity
-                            if (count($property->value)>1)
+                            //If array has only single element then property is unsupported from device
+                            if (count($property->value) > 1) {
                                 $updateVariable($entity->class[0], $name, $property->type, $property->value[0] /* 0 = current period */, 'Electricity');
+                            }
                             break;
                         default:
                             $this->SendDebug($name, $entity->class[0] . ' = ' . print_r($property, true), 0);


### PR DESCRIPTION
Ohne diesen Patch wurde das Skript nicht vollständig ausgeführt. Entsprechend wurden Werte nicht mehr updated bzw. auch nicht Statusvariablen beim Einrichten vollständig angelegt.


> Ursprüngliche Fehlermeldung:
> <b>Notice</b>:  Undefined offset: 0 in <b>/var/lib/symcon/modules/Viessmann/VitoConnect/module.php</b> on line <b>347</b><br />
> 


Meine Anlage: Vitodens 200 mit Vitotronic 200 (HO1) - Gas und Solar aber kein Photovoltaik.

